### PR TITLE
#35: add Slither GitHub workflow (#36)

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,11 @@
+name: Slither Analysis
+on: [push]
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crytic/slither-action@v0.4.0

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,3 @@
+{
+    "detectors_to_exclude": ["assembly", "pragma", "solc-version", "uninitialized-local"]
+}


### PR DESCRIPTION
* #35: add Slither GitHub workflow

* #35: check result from transferFrom

* #35: only mark loan as started if the transfer succeeds

* Exclude uninitialized local because it wastes gas

* #35: exclude pragma since we can't forcibly upgrade OpenZepplin

* #35: exclude solc-version since we can't forcibly upgrade OpenZepplin

* #35: protect against re-entrancy of event emission

* #35: don't re-write back to map; just use storage

* #35: restrict permissions of workflow

* #35: move state writes to before transferFrom calls to protect against reentrancy

* #35: ignore assembly, as that's from OpenZepplin